### PR TITLE
更新 README 主程序项目地址。

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ClassIsland 集控服务器。
 
-> **注意：本项目是ClassIsland集控服务器。如果您要查找ClassIsland软件本体，请前往仓库[HelloWRC/ClassIsland](https://github.com/HelloWRC/ClassIsland)**
+> **注意：本项目是ClassIsland集控服务器。如果您要查找ClassIsland软件本体，请前往仓库[ClassIsland/ClassIsland](https://github.com/ClassIsland/ClassIsland)**
 
 ## 功能
 


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change updates the repository link for the ClassIsland software to reflect the correct GitHub organization.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5): Updated the repository link from `HelloWRC/ClassIsland` to `ClassIsland/ClassIsland` to point to the correct location.